### PR TITLE
Include lwip header for IP string conversion

### DIFF
--- a/components/wifi_manager/wifi_manager.c
+++ b/components/wifi_manager/wifi_manager.c
@@ -4,6 +4,7 @@
 #include "esp_event.h"
 #include "esp_netif.h"
 #include <string.h>
+#include "lwip/ip4_addr.h"
 
 #define WIFI_SSID "myssid"
 #define WIFI_PASS "mypassword"


### PR DESCRIPTION
## Summary
- include `lwip/ip4_addr.h` to provide `ip4addr_ntoa` declaration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68584ed0a5c08323872d4d88aef3cc57